### PR TITLE
Fix: Can't use ref

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-simple-checkbox",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/Checkbox/Checkbox.jsx
+++ b/src/Checkbox/Checkbox.jsx
@@ -35,8 +35,7 @@ function getColors(propsColor) {
   return colors;
 }
 
-
-const Checkbox = ({
+const Checkbox = React.forwardRef(({
   backAnimationDuration,
   borderThickness,
   checked,
@@ -48,7 +47,7 @@ const Checkbox = ({
   size,
   tickAnimationDuration,
   tickSize,
-}) => {
+}, ref) => {
   const classes = ['Checkbox'];
   classes.push(className);
   classes.push(checked ? 'checked' : 'unchecked');
@@ -65,6 +64,7 @@ const Checkbox = ({
 
   return (
     <div
+      ref={ref}
       className={classes.join(' ')}
       role="checkbox"
       aria-checked="false"
@@ -115,7 +115,7 @@ const Checkbox = ({
       </svg>
     </div>
   );
-};
+});
 
 Checkbox.propTypes = {
   backAnimationDuration: PropTypes.number,


### PR DESCRIPTION
Issue https://github.com/Opsolem/react-simple-checkbox/issues/5.

We can't use useRef since this component doesn't receive and pass a ref forward.

This pull request implements `React.forwardRef` in order to make this work.